### PR TITLE
Preparing to remove JobTerminator

### DIFF
--- a/src/main/kotlin/com/adidas/mvi/IntentExecutor.kt
+++ b/src/main/kotlin/com/adidas/mvi/IntentExecutor.kt
@@ -1,7 +1,8 @@
 package com.adidas.mvi
 
+import com.adidas.mvi.transform.Transform
 import kotlinx.coroutines.flow.Flow
 
-public fun interface IntentExecutor<TIntent : Intent, TTransform> {
-    public fun executeIntent(intent: TIntent, jobTerminator: JobTerminator<TIntent>): Flow<TTransform>
+public fun interface IntentExecutor<TIntent : Intent, TState : State> {
+    public fun executeIntent(intent: TIntent, jobTerminator: JobTerminator<TIntent>): Flow<Transform<TState>>
 }

--- a/src/main/kotlin/com/adidas/mvi/Reducer.kt
+++ b/src/main/kotlin/com/adidas/mvi/Reducer.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -16,17 +17,28 @@ import kotlinx.coroutines.launch
 import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 
-public class Reducer<TIntent, TState, TTransform>(
+public typealias SimplifiedIntentExecutor<TIntent, TState> = (intent: TIntent) -> Flow<Transform<TState>>
+
+public class Reducer<TIntent, TState> @Deprecated("Use the other constructor, this option will be deprecated in the future") constructor(
     private val coroutineScope: CoroutineScope,
     initialState: TState,
     private val logger: Logger? = null,
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    private val intentExecutor: IntentExecutor<TIntent, TTransform>
+    private val intentExecutor: IntentExecutor<TIntent, TState>
 ) where TIntent : Intent,
-        TState : State,
-        TTransform : Transform<TState> {
+        TState : State {
+    @Suppress("DEPRECATION")
+    public constructor(
+        coroutineScope: CoroutineScope,
+        initialState: TState,
+        intentExecutor: SimplifiedIntentExecutor<TIntent, TState>,
+        logger: Logger? = null,
+        defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+    ) : this(coroutineScope, initialState, logger, defaultDispatcher, { intent, _ ->
+        intentExecutor(intent)
+    })
 
-    private val _transforms = MutableSharedFlow<TTransform>()
+    private val _transforms = MutableSharedFlow<Transform<TState>>()
     // TODO 2: use another (simpler) data structure once we remove jobTerminator dependency (1) - https://tools.adidas-group.com/jira/browse/HXC-819 [2]
     private val multimap = Multimap<TIntent, Job>()
 
@@ -72,7 +84,7 @@ public class Reducer<TIntent, TState, TTransform>(
     public inline fun <reified T : TState> requireState(): T = state.value as T
 
     @Suppress("FunctionName")
-    private suspend fun reduce(previousState: TState, transform: TTransform): TState {
+    private suspend fun reduce(previousState: TState, transform: Transform<TState>): TState {
         return try {
             transform.reduce(previousState, defaultDispatcher).also { newState ->
                 logger?.logTransformedNewState(transform, previousState, newState)

--- a/src/test/kotlin/com/adidas/mvi/reducer/TestCancellationReducerWrapper.kt
+++ b/src/test/kotlin/com/adidas/mvi/reducer/TestCancellationReducerWrapper.kt
@@ -1,7 +1,6 @@
 package com.adidas.mvi.reducer
 
 import com.adidas.mvi.CoroutineListener
-import com.adidas.mvi.JobTerminator
 import com.adidas.mvi.Logger
 import com.adidas.mvi.Reducer
 import io.mockk.mockk
@@ -31,8 +30,7 @@ internal class TestCancellationReducerWrapper(
     }
 
     private fun executeIntent(
-        intent: TestIntent,
-        jobTerminator: JobTerminator<TestIntent>
+        intent: TestIntent
     ): Flow<TestTransform> {
         return when (intent) {
             TestIntent.AbelIntent -> someTestFlow.map { TestTransform.AbelTransform }


### PR DESCRIPTION
- Deprecated the constructor that asks for an IntentExecutor which asks for a jobTerminator
- Removed a generic parameter for the Transform inside the Reducer