### PR TITLE
 Add TestMviLogger 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ ktlint-gradle = "12.1.0"
 android-library = "8.3.2"
 maven-publish = "0.29.0"
 ui = "1.7.1"
-mockk = "1.13.11"
 mvi-kotest = "0.0.2"
 
 # its beeing used outside this file
@@ -43,7 +42,6 @@ koinAndroid = { module = "io.insert-koin:koin-android", version.ref = "koin-andr
 koinAnnotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin-annotations" }
 koinKspCompiler = { module = "io.insert-koin:koin-ksp-compiler", version.ref = "koin-annotations" }
 koinCompose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-compose" }
-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/mvi-kotest/src/main/kotlin/com/adidas/mvi/kotest/TestMviLogger.kt
+++ b/mvi-kotest/src/main/kotlin/com/adidas/mvi/kotest/TestMviLogger.kt
@@ -1,0 +1,56 @@
+package com.adidas.mvi.kotest
+
+import com.adidas.mvi.Loggable
+import com.adidas.mvi.Logger
+
+/**
+ * A fake implementation of [Logger] that remembers all logged entries, for use in tests.
+ *
+ * You can access list of all logged entries from [loggedTranformations] and [loggedIntents].
+ */
+public class TestMviLogger : Logger {
+    public val loggedTranformations: MutableList<LoggedTranformation> = ArrayList<LoggedTranformation>()
+    public val loggedIntents: MutableList<LoggedIntent> = ArrayList<LoggedIntent>()
+
+    override fun logFailedIntent(
+        intent: Loggable,
+        throwable: Throwable,
+    ) {
+        loggedIntents += LoggedIntent.Failure(intent, throwable)
+    }
+
+    override fun logIntent(intent: Loggable) {
+        loggedIntents += LoggedIntent.Success(intent)
+    }
+
+    override fun logFailedTransformNewState(
+        transform: Loggable,
+        state: Loggable,
+        throwable: Throwable,
+    ) {
+        loggedTranformations += LoggedTranformation.Failure(transform, state, throwable)
+    }
+
+    override fun logTransformedNewState(
+        transform: Loggable,
+        previousState: Loggable,
+        newState: Loggable,
+    ) {
+        loggedTranformations += LoggedTranformation.Success(transform, previousState, newState)
+    }
+
+    public sealed class LoggedIntent() {
+        public abstract val intent: Loggable
+
+        public data class Success(override val intent: Loggable) : LoggedIntent()
+        public data class Failure(override val intent: Loggable, val throwable: Throwable) : LoggedIntent()
+    }
+
+    public sealed class LoggedTranformation() {
+        public abstract val transform: Loggable
+        public abstract val previousState: Loggable
+
+        public data class Success(override val transform: Loggable, override val previousState: Loggable, val newState: Loggable) : LoggedTranformation()
+        public data class Failure(override val transform: Loggable, override val previousState: Loggable, val throwable: Throwable) : LoggedTranformation()
+    }
+}

--- a/mvi-sample/build.gradle.kts
+++ b/mvi-sample/build.gradle.kts
@@ -88,6 +88,5 @@ dependencies {
     ksp(libs.koinKspCompiler)
 
     testImplementation(libs.kotestRunner)
-    testImplementation(libs.mockk)
-    testImplementation(libs.mviKotest)
+    testImplementation(project(":mvi-kotest"))
 }

--- a/mvi-sample/src/test/kotlin/com/adidas/mvi/sample/login/viewmodel/LoginViewModelTest.kt
+++ b/mvi-sample/src/test/kotlin/com/adidas/mvi/sample/login/viewmodel/LoginViewModelTest.kt
@@ -1,10 +1,10 @@
 package com.adidas.mvi.sample.login.viewmodel
 
 import com.adidas.mvi.kotest.GivenViewModel
+import com.adidas.mvi.kotest.TestMviLogger
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -19,7 +19,7 @@ class LoginViewModelTest : BehaviorSpec({
 
     fun getViewModel(): LoginViewModel {
         return LoginViewModel(
-            logger = mockk(relaxed = true),
+            logger = TestMviLogger(),
             coroutineDispatcher = testCoroutineDispatcher
         )
     }


### PR DESCRIPTION
PR adds TestMviLogger that can be used as a substitute for the Logger interface in tests and to extract logged data (for example passed exceptions).

This completely removes the need for mocks, so second commits uses this in a test and removes mockk from the repo.