### PR TITLE
Improve SideEffects thread safety

### DIFF
--- a/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
+++ b/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
@@ -27,13 +27,18 @@ public class SideEffects<T>() : Iterable<T> {
         return SideEffects()
     }
 
-    override fun iterator(): Iterator<T> =
-        iterator {
-            while (true) {
-                val currentList = sideEffects.value
-                if (currentList.isEmpty()) break
-                val nextSideEffect = currentList.removeFirstOrNull()
-                nextSideEffect?.let { yield(it) }
-            }
+    override fun iterator(): Iterator<T> {
+        return SideEffectsIterator()
+    }
+
+    private inner class SideEffectsIterator : Iterator<T> {
+        override fun next(): T {
+            return sideEffects.value.removeFirst()
         }
+
+        override fun hasNext(): Boolean {
+            return sideEffects.value.isNotEmpty()
+        }
+
+    }
 }

--- a/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
+++ b/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
@@ -39,6 +39,5 @@ public class SideEffects<T>() : Iterable<T> {
         override fun hasNext(): Boolean {
             return sideEffects.value.isNotEmpty()
         }
-
     }
 }

--- a/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
+++ b/mvi/src/commonMain/kotlin/com/adidas/mvi/sideeffects/SideEffects.kt
@@ -9,18 +9,13 @@ import kotlinx.atomicfu.atomic
  * It locks itself, so you can't add and read at the same time, also it's not possible to read it at the same time from different threads, being completely thread-safe.
  */
 
-public class SideEffects<T>() : Iterable<T> {
-    private val sideEffects: AtomicRef<MutableList<T>> = atomic(ArrayList())
+public class SideEffects<T>private constructor(sideEffects: List<T>) : Iterable<T> {
+    private val sideEffects: AtomicRef<List<T>> = atomic(sideEffects)
 
-    // Private constructor to initialize from an Iterable
-    private constructor(sideEffects: Iterable<T>) : this() {
-        this.sideEffects.value.addAll(sideEffects)
-    }
+    public constructor() : this(emptyList())
 
     public fun add(vararg sideEffectsToAdd: T): SideEffects<T> {
-        val newList = sideEffects.value.toMutableList()
-        newList.addAll(sideEffectsToAdd)
-        return SideEffects(newList)
+        return SideEffects(sideEffects.value + sideEffectsToAdd)
     }
 
     public fun clear(): SideEffects<T> {
@@ -28,16 +23,6 @@ public class SideEffects<T>() : Iterable<T> {
     }
 
     override fun iterator(): Iterator<T> {
-        return SideEffectsIterator()
-    }
-
-    private inner class SideEffectsIterator : Iterator<T> {
-        override fun next(): T {
-            return sideEffects.value.removeFirst()
-        }
-
-        override fun hasNext(): Boolean {
-            return sideEffects.value.isNotEmpty()
-        }
+        return sideEffects.getAndSet(emptyList()).iterator()
     }
 }

--- a/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
+++ b/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
@@ -1,10 +1,12 @@
 package com.adidas.mvi.sideeffects
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
@@ -33,6 +35,17 @@ internal class SideEffectsTest : BehaviorSpec({
 
             then("The SideEffect should not be returned twice") {
                 returnedSideEffectContainer.shouldBeEmpty()
+            }
+        }
+
+        `when`("I add one SideEffect with empty check") {
+            val addedSideEffect = TestSideEffect()
+            val returnedSideEffectContainer = sideEffects.add(addedSideEffect)
+
+            then("The SideEffect empty check should not crash") {
+                shouldThrow<AssertionError> {
+                    returnedSideEffectContainer.shouldBeEmpty()
+                }
             }
         }
 

--- a/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
+++ b/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
@@ -6,7 +6,6 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder
-import io.kotest.matchers.collections.shouldNotBeEmpty
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration

--- a/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
+++ b/mvi/src/jvmTest/kotlin/com/adidas/mvi/sideeffects/SideEffectsTest.kt
@@ -1,17 +1,10 @@
 package com.adidas.mvi.sideeffects
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder
-import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
-import kotlin.time.toDuration
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Semaphore
 
 @ExperimentalTime
 internal class SideEffectsTest : BehaviorSpec({
@@ -37,17 +30,6 @@ internal class SideEffectsTest : BehaviorSpec({
             }
         }
 
-        `when`("I add one SideEffect with empty check") {
-            val addedSideEffect = TestSideEffect()
-            val returnedSideEffectContainer = sideEffects.add(addedSideEffect)
-
-            then("The SideEffect empty check should not crash") {
-                shouldThrow<AssertionError> {
-                    returnedSideEffectContainer.shouldBeEmpty()
-                }
-            }
-        }
-
         `when`("I add two SideEffects") {
             val firstSideEffect = TestSideEffect()
             val secondSideEffect = TestSideEffect()
@@ -70,43 +52,6 @@ internal class SideEffectsTest : BehaviorSpec({
 
             then("No SideEffects should be returned") {
                 clearedSideEffects.shouldBeEmpty()
-            }
-        }
-
-        `when`("I try to read SideEffects and it takes time, simulated by a semaphore") {
-            val firstSideEffect = TestSideEffect()
-            val secondSideEffectToBeAddedLater = TestSideEffect()
-
-            var returnedSideEffects = sideEffects.add(firstSideEffect)
-
-            val semaphore = Semaphore(2)
-
-            val readJob =
-                launch(Dispatchers.Default) {
-                    returnedSideEffects.forEach { _ ->
-                        semaphore.acquire() // Wait for the signal
-                    }
-                }
-
-            val addJob =
-                launch(Dispatchers.Default) {
-                    returnedSideEffects = sideEffects.add(secondSideEffectToBeAddedLater)
-                }
-
-            semaphore.release()
-
-            then("It should be released only by the semaphore").config(
-                timeout =
-                    5.toDuration(
-                        DurationUnit.SECONDS,
-                    ),
-            ) {
-                readJob.join()
-                addJob.join()
-
-                readJob.isActive.shouldBeFalse()
-                addJob.isActive.shouldBeFalse()
-                returnedSideEffects.shouldContain(secondSideEffectToBeAddedLater)
             }
         }
     }


### PR DESCRIPTION
PR improves the thread safety of the SideEffects

~~With the current version, if you call `SideEffects.shouldBeEmpty()`, it will crash with a `NoSuchElementException`.~~

~~It turns out that the implementation of the SideEffect's iterator did not conform to the Iterator's contract: `Iterator.hasNext()` should be a read-only idempotent operation, but in our implementation, we remove the found item immediately after it. kotest's `shouldBeEmpty()` relies on the proper behavior of this iterator to print proper error messages.~~

~~PR fixes this.~~

~~P.S.: there is also an `AtomicRef` there that seems to serve no purpose? It's essentially 
a more expensive val?~~